### PR TITLE
Fix for blood-belt-express recipe

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -52,7 +52,11 @@ bloodbelt_config_lut["express-transport-belt"] = {
 
 function bloodbelt_modify_recipe(belt_type)
     local config         = bloodbelt_config_lut[belt_type]
-    local bbrecipe       = table.deepcopy(data.raw.recipe[belt_type])
+    if belt_type == "express-transport-belt" then
+		  bbrecipe = table.deepcopy(data.raw.recipe["fast-transport-belt"])
+	  else
+		  bbrecipe = table.deepcopy(data.raw.recipe[belt_type])
+	  end
 
     bbrecipe.name        = "blood-belt" .. config.name_suffix
     bbrecipe.enabled     = false


### PR DESCRIPTION
This one was a head scratcher. The recipe for express belts has an expensive variant. The code as written did not make the alteration correctly to modify that recipe, leaving one with no express blood belt recipe and duplicate express belt recipes.

The original code got around this I suspect by doing a deepcopy on the fast-belt recipe and avoiding the issue. As my Lua is not nearly swift enough (especially at 2:30 AM!) to figure out how to modify the normal/expensive recipe, I instead do this simple-ish tweak to handle the express case in a similar vein to the original implementation.

A quick test on my end shows it working, but additional eyes would always be beneficial, because 2 AM. Cheers!